### PR TITLE
Member, Diary 기능 개선

### DIFF
--- a/EASY_TO_WORKOUT/src/main/java/controller/diary/DetailDiaryController.java
+++ b/EASY_TO_WORKOUT/src/main/java/controller/diary/DetailDiaryController.java
@@ -31,17 +31,21 @@ public class DetailDiaryController implements Controller {
 			
 			return "redirect:/diary/my/list";
 		}
-
-		Diary diary = manager.getDiaryById(diaryId);
 		
-		request.setAttribute("diary", diary);
-		if (memberId.equals(diary.getAuthor())) {
-			request.setAttribute("isAuthor", true);
-		} else {
-			request.setAttribute("isAuthor", false);
+		try {
+			Diary diary = manager.getDiaryById(diaryId);
+			
+			request.setAttribute("diary", diary);
+			if (memberId.equals(diary.getAuthor())) {
+				request.setAttribute("isAuthor", true);
+			} else {
+				request.setAttribute("isAuthor", false);
+			}
+			
+			return "/diary/diary_detail.jsp";
+		} catch (Exception e) {
+			return "redirect:/diary/all/list";
 		}
-		
-		return "/diary/diary_detail.jsp";
 	}
 
 }

--- a/EASY_TO_WORKOUT/src/main/java/controller/diary/UpdateDiaryController.java
+++ b/EASY_TO_WORKOUT/src/main/java/controller/diary/UpdateDiaryController.java
@@ -22,30 +22,34 @@ public class UpdateDiaryController implements Controller {
 		
 		DiaryManager manager = DiaryManager.getInstance();
 		
-		if (request.getMethod().equals("GET")) {
-			int diaryId = Integer.parseInt(request.getParameter("diaryId"));
-			Diary diary = manager.getDiaryById(diaryId);
+		try {
+			if (request.getMethod().equals("GET")) {
+				int diaryId = Integer.parseInt(request.getParameter("diaryId"));
+				Diary diary = manager.getDiaryById(diaryId);
+				
+				request.setAttribute("diary", diary);
+				
+				return "/diary/diary_updateForm.jsp";
+			}
 			
-			request.setAttribute("diary", diary);
+			Diary updateDiary = new Diary();
+			updateDiary.setDiaryId(Integer.parseInt(request.getParameter("diaryId")));
+			updateDiary.setTitle(request.getParameter("diaryTitle"));
+			updateDiary.setWorkTime(Integer.parseInt(request.getParameter("workTime")));
+			updateDiary.setContents(request.getParameter("diaryContents"));
+			if (request.getParameter("isPrivate") == null) {
+				updateDiary.setIsPrivate(0);
+			}
+			else {
+				updateDiary.setIsPrivate(1);
+			}
 			
-			return "/diary/diary_updateForm.jsp";
+			manager.update(updateDiary);
+			
+			return "redirect:/diary/my/list";
+		} catch (Exception e) {
+			return "redirect:/diary/all/list";
 		}
-		
-		Diary updateDiary = new Diary();
-		updateDiary.setDiaryId(Integer.parseInt(request.getParameter("diaryId")));
-		updateDiary.setTitle(request.getParameter("diaryTitle"));
-		updateDiary.setWorkTime(Integer.parseInt(request.getParameter("workTime")));
-		updateDiary.setContents(request.getParameter("diaryContents"));
-		if (request.getParameter("isPrivate") == null) {
-			updateDiary.setIsPrivate(0);
-		}
-		else {
-			updateDiary.setIsPrivate(1);
-		}
-		
-		manager.update(updateDiary);
-		
-		return "redirect:/diary/my/list";
 	}
 
 }

--- a/EASY_TO_WORKOUT/src/main/java/controller/member/MemberSessionUtils.java
+++ b/EASY_TO_WORKOUT/src/main/java/controller/member/MemberSessionUtils.java
@@ -46,14 +46,25 @@ public class MemberSessionUtils {
     		Member loginMember = memberManager.findMember(getLoginMemberId(session));
     		request.setAttribute("loginMember", loginMember);
     		
+    		if (loginMember.getGrade().equals("master")) {
+    			request.setAttribute("isMaster", true);
+    		}
+    		
     		List<Membership> membershipList = membershipManager.getClubListByMemberId(loginMember.getId());
     		if (membershipList != null) {
-    			List<Club> clubList = new ArrayList<Club>();
+    			List<Club> myClubList = new ArrayList<Club>();
+    			List<Club> masterClubList = new ArrayList<Club>();
     			for (Membership membership : membershipList) {
     				Club club = clubManager.getClubById(membership.getClubId());
-    				clubList.add(club);
+    				if (club.getClubMaster().equals(loginMember.getId())) {
+    					masterClubList.add(club);
+    				}
+    				else {
+						myClubList.add(club);
+    				}
     			}
-    			request.setAttribute("myClubList", clubList);
+    			request.setAttribute("myClubList", myClubList);
+    			request.setAttribute("masterClubList", masterClubList);
     		}
     		
     	} catch (Exception e) {

--- a/EASY_TO_WORKOUT/src/main/webapp/WEB-INF/member/memberInfo.jsp
+++ b/EASY_TO_WORKOUT/src/main/webapp/WEB-INF/member/memberInfo.jsp
@@ -14,9 +14,7 @@
 						<c:when test="${loginMember.grade eq 'green'}">새싹</c:when>
 						<c:otherwise>마스터</c:otherwise>
 					</c:choose>
-					<p /> <br> <a href="<c:url value='/member/update'>
-									<c:param name='memberId' value='${loginMember.id}' />
-								</c:url>">회원정보 수정</a>
+					<p /> <br> <a href="<c:url value='/member/update' />">회원정보 수정</a>
 					<p>
 						<a href="<c:url value='/member/logout' />">로그아웃</a>
 				</td>

--- a/EASY_TO_WORKOUT/src/main/webapp/WEB-INF/member/memberInfo.jsp
+++ b/EASY_TO_WORKOUT/src/main/webapp/WEB-INF/member/memberInfo.jsp
@@ -23,6 +23,18 @@
 			</tr>
 		</table>
 		<br><hr>
+		<c:if test="${isMaster}">
+			<article>
+				<h4 style="margin: 20px;">개설 모임 목록</h4>
+				<ul>
+					<c:forEach var="club" items="${masterClubList}">
+						<li><a href="<c:url value='/club/detail'>
+										<c:param name='clubId' value='${club.clubId}' />
+									</c:url>">${club.clubName}</a></li>
+					</c:forEach>
+				</ul>
+			</article>
+		</c:if>
 		<article>
 			<h4 style="margin: 20px;">내 모임 목록</h4>
 			<ul>

--- a/EASY_TO_WORKOUT/src/main/webapp/WEB-INF/member/memberInfo.jsp
+++ b/EASY_TO_WORKOUT/src/main/webapp/WEB-INF/member/memberInfo.jsp
@@ -15,7 +15,7 @@
 						<c:otherwise>마스터</c:otherwise>
 					</c:choose>
 					<p /> <br> <a href="<c:url value='/member/update'>
-									<c:param name='member' value='${loginMember}' />
+									<c:param name='memberId' value='${loginMember.id}' />
 								</c:url>">회원정보 수정</a>
 					<p>
 						<a href="<c:url value='/member/logout' />">로그아웃</a>


### PR DESCRIPTION
1. 회원 정보 틀에 개설한 모임의 목록과 가입한 모임의 목록이 구분되도록 구현
2. 회원정보 수정 페이지로 이동할 때 member 객체를 전달하지 않고 session에서 loginMember의 정보를 찾아 페이지를 구현하는 방식으로 수정
3. Diary detail, update 페이지로 이동할 때 존재하지 않는 diaryId 값이 주어질 경우 /diary/all/list로 이동하도록 예외 처리